### PR TITLE
Persist variables until a tag has been executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const XRegExp = require('xregexp')
 const parsers = require('./src/parsers/controller')
 const mergeObjects = require('./src/utils').mergeObjects
+const events = require('./src/events')
 
 const matchRecursive = str => XRegExp.matchRecursive(str, '{', '}', 'gi')
 
@@ -77,7 +78,12 @@ function parse (string, args, _callback) {
       }
 
       if (!isRootFunc) _callback(parsedString)
-      else return parsedString
+      else {
+        // Clear tags registered within the message
+        // Even if args.id isn't supplied tags will stick around, but this is harmless since snowflakes are unique
+        if (args && args.id) events.clearTags(args.id)
+        return parsedString
+      }
     }
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,12 @@
+// Event emitter system to avoid exposing the database to the end user
+const EventEmitter = require('events')
+
+class Dispatcher extends EventEmitter {
+  clearTags (messageId) {
+    this.emit('CLEAR_TAGS', messageId)
+  }
+}
+
+const events = new Dispatcher()
+
+module.exports = events

--- a/src/parsers/variables.js
+++ b/src/parsers/variables.js
@@ -1,15 +1,18 @@
 const Loki = require('lokijs')
+const events = require('../events')
 const db = new Loki('../../jtvars.data')
 
 const variables = db.addCollection('variables')
 
+events.on('CLEAR_TAGS', messageId => {
+  variables.findAndRemove({
+    createdIn: messageId
+  })
+})
+
 const parsers = {
   get: (args, name) => {
     let result = variables.findOne({
-      name: name,
-      createdIn: args.id
-    })
-    variables.findAndRemove({
       name: name,
       createdIn: args.id
     })

--- a/test/variables.test.js
+++ b/test/variables.test.js
@@ -9,6 +9,10 @@ describe('Variable parser', () => {
     expect(JagTagParser('{set:foo|bar}The variable foo is {get:foo}', { id: randstr(18) })).toBe('The variable foo is bar')
   })
 
+  it('Allows the same variable to be reused within a single tag', () => {
+    expect(JagTagParser('{set:foo|bar}Foo is {get:foo} and is still {get:foo}', { id: randstr(18) })).toBe('Foo is bar and is still bar')
+  })
+
   it('Returns undefined if a variable that is not defined is fetched', () => {
     expect(JagTagParser('{get:foo}', { id: randstr(18) })).toBe('undefined')
   })


### PR DESCRIPTION
* Changed variable persistence from one-use to string-level
* Added simple event system to avoid exposing the database to the end user